### PR TITLE
pulsar: Replace OAuth2 auth with JWT token

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,16 +178,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-attributes"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "async-channel"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -268,18 +258,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-native-tls"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d57d4cec3c647232e1094dc013546c0b33ce785d8aeb251e1f20dfaf8a9a13fe"
-dependencies = [
- "futures-util",
- "native-tls",
- "thiserror",
- "url",
-]
-
-[[package]]
 name = "async-object-pool"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -335,7 +313,6 @@ version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62565bb4402e926b29953c785397c6dc0391b7b446e45008b0049eb43cec6f5d"
 dependencies = [
- "async-attributes",
  "async-channel",
  "async-global-executor",
  "async-io",
@@ -372,19 +349,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.15",
-]
-
-[[package]]
-name = "asynchronous-codec"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06a0daa378f5fd10634e44b0a29b2a87b890657658e072a30d6f26e57ddee182"
-dependencies = [
- "bytes",
- "futures-sink",
- "futures-util",
- "memchr",
- "pin-project-lite",
 ]
 
 [[package]]
@@ -1463,12 +1427,6 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
-
-[[package]]
-name = "data-url"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d7439c3735f405729d52c3fbbe4de140eaf938a1fe47d227c27f8254d4302a5"
 
 [[package]]
 name = "dbl"
@@ -3324,15 +3282,11 @@ version = "5.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20f237570b5665b38c7d5228f9a1d2990e369c00e635704528996bcd5219f540"
 dependencies = [
- "async-native-tls",
- "async-std",
  "async-trait",
- "asynchronous-codec",
  "bit-vec",
  "bytes",
  "chrono",
  "crc",
- "data-url",
  "flate2",
  "futures",
  "futures-io",
@@ -3341,16 +3295,12 @@ dependencies = [
  "lz4",
  "native-tls",
  "nom",
- "oauth2",
- "openidconnect",
  "pem",
  "prost",
  "prost-build",
  "prost-derive",
  "rand",
  "regex",
- "serde",
- "serde_json",
  "snap",
  "tokio",
  "tokio-native-tls",

--- a/chirpstack/Cargo.toml
+++ b/chirpstack/Cargo.toml
@@ -69,7 +69,7 @@ lapin = "2.1"
 tokio-executor-trait = "2.1"
 tokio-reactor-trait = "1.1"
 rdkafka = { version = "0.29", features = ["cmake-build"] }
-pulsar = {  version = "5.1" }
+pulsar = { version = "5.1", default-features = false, features = ["compression", "tokio-runtime"] }
 # gRPC and Protobuf
 tonic = "0.9"
 tonic-web = "0.9"

--- a/chirpstack/src/config.rs
+++ b/chirpstack/src/config.rs
@@ -317,30 +317,10 @@ impl Default for PostgresqlIntegration {
 
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(default)]
-pub struct PulsarIntegrationOAuth2 {
-    pub issuer_url: String,
-    pub credentials_url: String,
-    pub audience: Option<String>,
-    pub scope: Option<String>,
-}
-
-impl Default for PulsarIntegrationOAuth2 {
-    fn default() -> Self {
-        PulsarIntegrationOAuth2 {
-            issuer_url: "http://127.0.0.1".into(),
-            credentials_url: "http://127.0.0.1".into(),
-            audience: None,
-            scope: None,
-        }
-    }
-}
-
-#[derive(Serialize, Deserialize, Clone)]
-#[serde(default)]
 pub struct PulsarIntegration {
     pub server: String,
     pub event_topic: String,
-    pub oauth2_settings: Option<PulsarIntegrationOAuth2>,
+    pub auth_token: String,
     pub json: bool,
 }
 
@@ -350,7 +330,7 @@ impl Default for PulsarIntegration {
             server: "pulsar://127.0.0.1:6650".into(),
             // event_topic: "non-persistent://public/default/application.{{application_id}}.device.{{dev_eui}}.event.{{event}}".into(),
             event_topic: "application.{{application_id}}.device.{{dev_eui}}.event.{{event}}".into(),
-            oauth2_settings: None,
+            auth_token: "".to_string(),
             json: false,
         }
     }


### PR DESCRIPTION
For chirpstack kind of application, using OAuth2 for authentication is a bit awkward, to say the least, and JWT token based authentication is a better fit for machine-to-machine communication.

This removes the OAuth2 auth and replaces it with token based one.